### PR TITLE
Apply VolumeClaimTemplates to changed STSs

### DIFF
--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/resource/StatefulSetReconciler.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/resource/StatefulSetReconciler.java
@@ -34,6 +34,7 @@ public class StatefulSetReconciler implements Reconciler {
               new StatefulSetBuilder(r).editOrNewSpec()
                       .withMinReadySeconds(spec.getMinReadySeconds())
 //                      .withPersistentVolumeClaimRetentionPolicy(spec.getPersistentVolumeClaimRetentionPolicy()) // do not use because of feature gate?
+                      .withVolumeClaimTemplates(spec.getVolumeClaimTemplates())
                       .withReplicas(spec.getReplicas())
                       .withTemplate(spec.getTemplate())
                       .withUpdateStrategy(spec.getUpdateStrategy())


### PR DESCRIPTION
When disabling `with.cachesAsPvc`, make sure the StatefulSet is updated accordingly by re-defining the VolumeClaimTemplates.

Closes #139.