### PR TITLE
Do not adjust PersistentVolumeClaimTemplates in StatefulSets

### DIFF
--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/resource/StatefulSetReconciler.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/resource/StatefulSetReconciler.java
@@ -33,8 +33,6 @@ public class StatefulSetReconciler implements Reconciler {
       existing.edit(r ->
               new StatefulSetBuilder(r).editOrNewSpec()
                       .withMinReadySeconds(spec.getMinReadySeconds())
-//                      .withPersistentVolumeClaimRetentionPolicy(spec.getPersistentVolumeClaimRetentionPolicy()) // do not use because of feature gate?
-                      .withVolumeClaimTemplates(spec.getVolumeClaimTemplates())
                       .withReplicas(spec.getReplicas())
                       .withTemplate(spec.getTemplate())
                       .withUpdateStrategy(spec.getUpdateStrategy())


### PR DESCRIPTION
k8s does not allow removing PVCTs after the STS has been created.